### PR TITLE
fix plugin shortcut

### DIFF
--- a/Image Replaste.sketchplugin/Contents/Sketch/manifest.json
+++ b/Image Replaste.sketchplugin/Contents/Sketch/manifest.json
@@ -11,7 +11,7 @@
     {
       "script" : "image-replaste.js",
       "handler" : "onRun",
-      "shortcut" : "cmd shift y",
+      "shortcut" : "cmd сtrl i",
       "name" : "Image Replaste!",
       "identifier" : "image-replaste",
       "description" : "Replace your image with your pasteboard image",


### PR DESCRIPTION
sketch 64 uses last shortcuts for symbols